### PR TITLE
Add Jacoco coverage plugin in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
 }
 
 group 'com.ordestiny'
@@ -21,6 +22,30 @@ dependencies {
     // https://mvnrepository.com/artifact/org.assertj/assertj-core
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.17.2'
 }
+
+jacoco {
+    toolVersion = "0.8.5"
+    reportsDir = file("$buildDir/customJacocoReportDir")
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = 'CLASS'
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.9
+            }
+            excludes = [
+                    'io.reflectoring.coverage.part.PartlyCovered',
+                    'io.reflectoring.coverage.ignored.*',
+                    'io.reflectoring.coverage.part.NotCovered'
+            ]
+        }
+    }
+}
+
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION

Fixes #31 

This PR adds JaCoCo, the most actively maintained and sophisticated code coverage measurement tool for the Java ecosystem.

A report can be generated by running `./gradlew build jacocoTestReport`.
A rule of 90% coverage is set (as an example and can be changed) and the verification can be run by running `./gradlew build jacocoTestCoverageVerification`